### PR TITLE
Model Memory Leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,9 @@ Make sure you enable this option during the installation:
     - pip install peft
 	- One line to download all the libraries: 
     - pip install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126 && pip install diffusers accelerate transformers opencv-python pyOpenSSL controlnet_aux pillow mediapipe numpy timm peft
+
+- **Install the required libraries on python for Rhino:**
+  - # requirements: pillow
+
+- **Ensure Developer Mode is enabled on Windows:**
+  - https://docs.microsoft.com/en-us/windows/apps/get-started/enable-your-device-for-development

--- a/app.py
+++ b/app.py
@@ -22,7 +22,7 @@ import Eto.Forms as forms
 import Eto.Drawing as drawing
 from System.Drawing import Bitmap, Imaging
 from PIL import Image, ImageOps
-
+from System import GC
 # -------------------------------------------
 # make sure to change the env environment path
 # -------------------------------------------
@@ -192,15 +192,16 @@ def show_image_dialog():
             status_label.Text = f"Error: {str(e)}"
             ai_button.Enabled = True
     
-    def on_form_closing(sender, e):
+    def on_form_closed(sender, e):
         if image_view.Image is not None:
             image_view.Image = None
         check_loading_timer.Stop()
         flush()
+        GC.Collect()
     
     # Connect events
     ai_button.Click += on_ai_button_click
-    form.Closing += on_form_closing
+    form.Closed += on_form_closed
     
     form.Show()
     

--- a/app.py
+++ b/app.py
@@ -1,3 +1,4 @@
+# requirements: pillow
 
 #replace the following paths
 cache_path = "Z:\\Development Projects\\huggingface"

--- a/app.py
+++ b/app.py
@@ -33,8 +33,8 @@ sys.path.append(op.join(conda_env, r"Lib\site-packages"))
 os.add_dll_directory(op.join(conda_env, r'Library\bin'))
 
 from image_generation.image_generation import generate_from_rhino_view, initialize_models, is_loading_complete, flush
-# viewport to bitmap to pil image
 def capture_viewport():
+    """Capture viewport as pillow image"""
     view = sc.doc.Views.ActiveView
     bitmap = view.CaptureToBitmap()
     
@@ -46,8 +46,9 @@ def capture_viewport():
     
     return pil_image
 
-# pil to bitmap to eto
+
 def pil_to_eto_image(pil_image):
+    """Convert pillow image to Eto bitmap"""
     with tempfile.NamedTemporaryFile(suffix='.png', delete=False) as temp_file:
         temp_path = temp_file.name
     
@@ -62,12 +63,9 @@ def pil_to_eto_image(pil_image):
 
     return eto_bitmap
 
-# Initialize sticky dictionary for form reference
-# if 'negative_viewport_form' not in sc.sticky:
-#     sc.sticky['negative_viewport_form'] = None
 
-# creating the UI components
 def create_ui_controls():
+    """Create user interface"""
     # Create image view
     image_view = forms.ImageView()
     image_view.BackgroundColor = drawing.Color.FromArgb(255, 255, 255)
@@ -97,7 +95,7 @@ def create_ui_controls():
 
 
 def show_image_dialog():
-    
+    """Show user interface"""
     initialize_models()
     
     # Create form
@@ -206,6 +204,7 @@ def show_image_dialog():
     form.Show()
     
     return form
+
 
 if __name__ == "__main__":
     show_image_dialog()

--- a/app.py
+++ b/app.py
@@ -1,38 +1,23 @@
-# requirements: pillow
+import os
+import bootstrap_torchcuda
 
 #replace the following paths
-cache_path = "Z:\\Development Projects\\huggingface"
-conda_env = r'C:\envs\generative_rhino_ai'
-
-import os, sys, threading, tempfile
-import os.path as op
-# -------------------------------------------
-# make sure to change the cache path
-# -------------------------------------------
-cache_path = cache_path
+cache_path = r"C:\cache"
 os.environ["TRANSFORMERS_CACHE"] = cache_path
 os.environ["HF_HUB_CACHE"] = cache_path
 os.environ["HUGGINGFACE_HUB_CACHE"] = cache_path 
 os.environ["HF_HOME"] = cache_path
 
-import rhinoscriptsyntax as rs
-import Rhino
+import threading, tempfile
+from image_generation.image_generation import generate_from_rhino_view, initialize_models, is_loading_complete, flush
 import scriptcontext as sc
 import Eto.Forms as forms
 import Eto.Drawing as drawing
 from System.Drawing import Bitmap, Imaging
-from PIL import Image, ImageOps
+from PIL import Image
 from System import GC
-# -------------------------------------------
-# make sure to change the env environment path
-# -------------------------------------------
 
-# Configure environment
-conda_env = conda_env 
-sys.path.append(op.join(conda_env, r"Lib\site-packages"))
-os.add_dll_directory(op.join(conda_env, r'Library\bin'))
 
-from image_generation.image_generation import generate_from_rhino_view, initialize_models, is_loading_complete, flush
 def capture_viewport():
     """Capture viewport as pillow image"""
     view = sc.doc.Views.ActiveView

--- a/bootstrap_torchcuda/__init__.py
+++ b/bootstrap_torchcuda/__init__.py
@@ -1,0 +1,48 @@
+import threading
+from typing import List
+import clr
+clr.AddReference("Rhino.Runtime.Code")
+clr.AddReference("RhinoCodePlatform.Rhino3D")
+from Rhino.Runtime.Code import RhinoCode, ProcessResult, ProgressReport
+from Rhino.Runtime.Code.Languages import LanguageSpec
+from RhinoCodePlatform.Rhino3D.Languages import RhinoProgressBarRestoreReporter
+from Rhino import RhinoApp
+
+
+__bootstrapped__ = False
+
+
+def run_pip(py3, reporter, args, results):
+    """PIP installs using given arguments and sets global 'result'"""
+    result = py3.Environs.Shared.PIP(py3.Runtime, args, reporter, lambda _: None)
+    reporter.Report(ProgressReport.Complete)
+    results.append(result)
+
+
+def run_pip_async(args): 
+    """PIP installs on non-ui thread using given arguments"""
+    py3 = RhinoCode.Languages.QueryLatest(LanguageSpec.Python3)
+    if not py3:
+        raise Exception("Python 3 is somehow not found! Talk to ehsan@mcneel.com")
+
+    # start pip install on a separate thread
+    results: List[ProcessResult] = []
+    t = threading.Thread(target=run_pip, args=[py3, RhinoProgressBarRestoreReporter(), args, results])
+    t.start()
+
+    # pump the ui and wait for install result
+    while t.is_alive() and not results:
+        RhinoApp.Wait()
+    return results[0]
+
+
+if not __bootstrapped__:
+    r = run_pip_async("install torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu126")
+    if r.ExitCode != 0:
+        raise Exception(f"Failed installing torch with CUDA support: {r.Output}")
+
+    r = run_pip_async("install diffusers accelerate transformers opencv-python pyOpenSSL controlnet_aux pillow mediapipe numpy timm peft")
+    if r.ExitCode != 0:
+        raise Exception(f"Failed installing support packages: {r.Output}")
+
+    __bootstrapped__ = True

--- a/bootstrap_torchcuda/__init__.py
+++ b/bootstrap_torchcuda/__init__.py
@@ -1,5 +1,18 @@
+"""Torch with CUDA support bootstrapper.
+
+Reaches into Rhino 3d scripting API to use pip directly to install
+torch with cuda support from a custom index url.
+Installs all packages into site-packages environment since other
+envs under site-env are not suited for complex libs like torch.
+Uses scripting progress bar reporter to report install progress.
+
+Reach out for questions to Ehsan Iran-Nejad (ehsan@mcneel.com) or
+https://discourse.mcneel.com/u/eirannejad
+"""
 import threading
 from typing import List
+
+# ref necessary rhinocode api
 import clr
 clr.AddReference("Rhino.Runtime.Code")
 clr.AddReference("RhinoCodePlatform.Rhino3D")
@@ -9,13 +22,15 @@ from RhinoCodePlatform.Rhino3D.Languages import RhinoProgressBarRestoreReporter
 from Rhino import RhinoApp
 
 
+# global flag to avoid repeating work
+# every time this module is loaded in the same process.
 __bootstrapped__ = False
 
 
 def run_pip(py3, reporter, args, results):
-    """PIP installs using given arguments and sets global 'result'"""
+    """PIP installs using given arguments and adds result to the input results list"""
     result = py3.Environs.Shared.PIP(py3.Runtime, args, reporter, lambda _: None)
-    reporter.Report(ProgressReport.Complete)
+    reporter.Report(ProgressReport.Complete)    # completes progress and clears Rhino's progressbar
     results.append(result)
 
 

--- a/image_generation/image_generation.py
+++ b/image_generation/image_generation.py
@@ -9,15 +9,17 @@ import numpy as np
 from huggingface_hub import hf_hub_download
 import gc
 
+_pipeline = None
+_loading_complete = False
+_loading_thread = None
+
+
 def flush():
     gc.collect()
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
     gc.collect()
 
-_pipeline = None
-_loading_complete = False
-_loading_thread = None
 
 # model control
 def load_pipeline():

--- a/image_generation/image_generation.py
+++ b/image_generation/image_generation.py
@@ -15,7 +15,10 @@ _loading_thread = None
 
 
 def flush():
+    global _pipeline
+    _pipeline = None
     gc.collect()
+
     torch.cuda.empty_cache()
     torch.cuda.synchronize()
     gc.collect()
@@ -36,7 +39,7 @@ def load_pipeline():
     # Configure hardware
     if torch.cuda.is_available():
         pipe = pipe.to("cuda")
-        pipe.enable_model_cpu_offload()
+        # pipe.enable_model_cpu_offload()
     
     return pipe
 
@@ -102,7 +105,7 @@ def preprocess_image(image):
 def generate_from_rhino_view(image, prompt, pipeline=None, negative_prompt="ugly, low quality", 
                              guidance_scale=5, control_strength=0.5, num_inference_steps=8, seed=None):
     
-    pipe = pipeline if pipeline is not None else get_pipeline()
+    pipe = pipeline or get_pipeline() or load_pipeline()
     
     small_image = resize_image_small(image)
     processed_image = preprocess_image(small_image)

--- a/image_generation/image_generation.py
+++ b/image_generation/image_generation.py
@@ -1,13 +1,11 @@
-import sys, os, threading, time
-import os.path as op
-
+import threading
 import torch
 from diffusers import StableDiffusionXLControlNetPipeline, ControlNetModel
 from controlnet_aux import AnylineDetector
 from PIL import Image
 import numpy as np
-from huggingface_hub import hf_hub_download
 import gc
+
 
 _pipeline = None
 _loading_complete = False
@@ -15,8 +13,10 @@ _loading_thread = None
 
 
 def flush():
-    global _pipeline
+    """Dispose loaded models and flush caches"""
+    global _pipeline, _loading_thread
     _pipeline = None
+    _loading_thread = None
     gc.collect()
 
     torch.cuda.empty_cache()
@@ -24,8 +24,8 @@ def flush():
     gc.collect()
 
 
-# model control
 def load_pipeline():
+    """Load models, create image generation pipeline, and return the pipeline"""
     # Model configuration
     base_model_id = "SG161222/RealVisXL_V4.0"  
     controlnet_model_id = "xinsir/controlnet-canny-sdxl-1.0"
@@ -43,35 +43,34 @@ def load_pipeline():
     
     return pipe
 
-# starting a daemon thread 
+
 def initialize_models():
+    """Start a daemon thread that loads pipeline"""
+    def _load_models():
+        global _pipeline, _loading_complete, _loading_error
+        _loading_complete, _loading_error = False, None
+        _pipeline = load_pipeline()
+        _loading_complete = True
+
     global _loading_thread
     if _loading_thread is None or not _loading_thread.is_alive():
         _loading_thread = threading.Thread(target=_load_models)
         _loading_thread.daemon = True
         _loading_thread.start()
 
-# handeling loading the model pipeline
-def _load_models():
 
-    global _pipeline, _loading_complete, _loading_error
-
-    _loading_complete, _loading_error = False, None
-
-    _pipeline = load_pipeline()
-
-    _loading_complete = True
-
-# calling the pipeline
 def get_pipeline():
+    """Get loaded pipeline singleton"""
     return _pipeline
 
-# check if pipeline is loaded
+
 def is_loading_complete():
+    """Check if pipeline is loaded"""
     return _loading_complete
 
-# resizing the image 
+
 def resize_image_small(image, max_size=1024):
+    """Resize image magically"""
     def make_divisible_by_8(value):
         return (value // 8) * 8
 
@@ -93,18 +92,19 @@ def resize_image_small(image, max_size=1024):
     
     return image.resize((width, height), Image.LANCZOS)
 
-# generate a canny edge image 
+
 def preprocess_image(image):
+    """Generate a canny edge image"""
     img_processor = AnylineDetector.from_pretrained("TheMistoAI/MistoLine", filename="MTEED.pth", subfolder="Anyline")
     edges_rgb = img_processor(image)
     if isinstance(edges_rgb, np.ndarray):
         edges_rgb = Image.fromarray(edges_rgb)
     return edges_rgb
 
-# image generation
+
 def generate_from_rhino_view(image, prompt, pipeline=None, negative_prompt="ugly, low quality", 
                              guidance_scale=5, control_strength=0.5, num_inference_steps=8, seed=None):
-    
+    """Do magic!"""
     pipe = pipeline or get_pipeline() or load_pipeline()
     
     small_image = resize_image_small(image)


### PR DESCRIPTION
## July 15

- Added `bootstrap_torchcuda` module and added `import bootstrap_torchcuda` to the top of `app.py`. This handles getting torch-with-cuda-support install into the python 3 environment that belongs to Rhino.
- Removes condo dependency
- ⚠️ All packages are installed into `~\.rhinocode\py39-rh8\Lib\site-packages` instead of `site-envs`. This is to avoid bugs related to the environments in Rhino 8 and does a clean torch install. If you need to reset the python environment, from ScriptEditor menu run _Tools > Advanced > Reset Python 3 Runtime_
- Shows progress bar while installing packages
- Misc cleanups


On the first run, this takes about 5 to 8 minutes to download and install all the necessary packages and load the modules. Rhino interface remains active for the majority of this time:

https://github.com/user-attachments/assets/ce87023a-122a-429c-882b-a1585b0b4d41

On closing and opening Rhino it takes just over a minute to check environment and load the libraries:

https://github.com/user-attachments/assets/9a09aa48-66b3-423c-9056-73439173d690


## July 10
I had a moderate amount of success offloading the model by making these changes. See below for comments.

Mem use is about 3.5GB with just torch and other libraries loaded:
<img width="920" height="318" alt="procexp64_wQ0nDpXYKo" src="https://github.com/user-attachments/assets/6ee6dec4-1a8d-4d62-bfdb-3f821f5e4211" />

After opening the prompt dialog and waiting for the models to be loaded:
<img width="926" height="322" alt="procexp64_CrHFPBc4mz" src="https://github.com/user-attachments/assets/e4f32605-6787-49c4-8596-5a57d44da27a" />

With proposed changes here, closing the dialog drops to half the mem usage. I am assuming the rest are far-more-complicated internal references and memory block inside of torch and other libraries:
<img width="917" height="313" alt="procexp64_0q8550wsAw" src="https://github.com/user-attachments/assets/da1d859a-9249-4033-ab06-27aca6e9cab5" />

I hope this helps. It's half the memory at least :D 
Tracking native memory usage is pretty hard and tooling is not great. I suggest using:
- [VMMap](https://learn.microsoft.com/en-us/sysinternals/downloads/vmmap)
- [Process Explorer](https://learn.microsoft.com/en-us/sysinternals/downloads/process-explorer)

**Suggestion**

When dealing with high-resource-use scripts like these that do not rely much on Rhino API, it is better to run the model as a subprocess (see `subprocess` module) and wait for it to complete. The subprocess computes the pil image, write to disk and returns. Your script, as the parent process, will read the pil file, convert to Eto image and display on the UI. This has the benefit of dropping all the memory used by torch and ai models once the subprocess completes without affecting Rhino's memory usage at all. The downside is that it needs to load everything every time.

**Thank You ❤️**
Thanks for pushing the boundaries. It is so exciting to see python in Rhino can support. Makes me feel very lucky and energized to make it better!

<img width="1920" height="1032" alt="Rhino_n9j2DRiAVO" src="https://github.com/user-attachments/assets/66c03252-a730-4bfa-b4a0-7229b54d5fde" />
